### PR TITLE
fix(proxy): correctly detect SSE streaming + surface forwarding errors

### DIFF
--- a/src/proxy.py
+++ b/src/proxy.py
@@ -209,5 +209,7 @@ async def proxy_request(
                 media_type=response.headers.get("Content-Type", ""),
             )
 
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error forwarding request: {type(e).__name__}: {e}")

--- a/src/proxy.py
+++ b/src/proxy.py
@@ -157,7 +157,7 @@ async def proxy_request(
                 )
             raise HTTPException(status_code=response.status_code, detail=detail)
 
-        is_streaming_response = response.headers.get("content-type", "") == "text/event-stream"
+        is_streaming_response = "text/event-stream" in response.headers.get("content-type", "")
 
         if is_streaming_response:
 

--- a/src/proxy.py
+++ b/src/proxy.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from http import HTTPStatus
 from typing import Annotated
 
@@ -13,6 +14,8 @@ from src.config import ImageEditModelConfig, ImageModelConfig, TextModelConfig, 
 from src.image_generation import ImageModelManager
 from src.interfaces.usage import TextUsageFullData, UserContext
 from src.usage import report_usage_event_task, extract_usage_info_from_raw, extract_usage_info
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["Proxy service"])
 keys_manager = KeysManager()
@@ -84,6 +87,7 @@ async def proxy_health(request: Request, model_name: str):
     try:
         response: httpx.Response = await client.get(url, headers=headers)
     except Exception as e:
+        logger.exception("proxy health forward to %s failed", url)
         raise HTTPException(status_code=500, detail=f"Error forwarding request: {type(e).__name__}: {e}")
 
     return Response(
@@ -212,4 +216,5 @@ async def proxy_request(
     except HTTPException:
         raise
     except Exception as e:
+        logger.exception("proxy forward to %s failed", url)
         raise HTTPException(status_code=500, detail=f"Error forwarding request: {type(e).__name__}: {e}")


### PR DESCRIPTION
## Summary

Three related fixes to `src/proxy.py`, surfaced while debugging persistent silent 500s reported by a single streaming client against a Qwen3.5-122B-A10B vLLM backend.

1. **`fix(proxy): correctly detect SSE streaming responses`** — the exact-match check `content-type == \"text/event-stream\"` never matched in practice, because vLLM (and most OpenAI-compatible backends) return `text/event-stream; charset=utf-8`. Every streaming response was misrouted into the non-streaming branch, where `json.loads` was called on the SSE body and raised `JSONDecodeError` → generic 500. Switched to a substring match (`\"text/event-stream\" in ...`) so the check holds regardless of media-type parameters.

2. **`fix(proxy): pass HTTPException through instead of rewrapping as 500`** — the generic `except Exception` around the upstream forward also caught `HTTPException`, including the intentional `raise HTTPException(status_code=response.status_code, detail=...)` emitted when the upstream returned a 4xx. That silently rewrapped every upstream 4xx as a 500 with detail `\"Error forwarding request: HTTPException: ...\"`, masking the real error. Added an `except HTTPException: raise` before the catch-all so upstream status codes and error bodies pass through unchanged.

3. **`chore(proxy): log forwarding exceptions with logger.exception`** — FastAPI returns the detail to the client but never logs the original exception or traceback. In production, every proxy 500 was invisible in the journal except for the access-log line. Added `logger.exception(...)` calls (introducing a module-level `logger = logging.getLogger(__name__)`) before re-raising, so every future generic 500 lands in `journalctl -u libertai_api.service` with a full stack.

## Root cause investigation

Deployed the first two fixes + logging live on one of the production Qwen3.5-122B-A10B VMs behind the libertai API. The traceback logging immediately showed the actual failure mode:

\`\`\`
proxy forward exception: JSONDecodeError: Expecting value: line 1 column 1 (char 0)
Traceback (most recent call last):
  File \"/opt/libertai/libertai-models/src/proxy.py\", line 184, in proxy_request
    response_json = json.loads(response_bytes)
...
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
\`\`\`

A direct probe against the upstream confirmed: `content-type: text/event-stream; charset=utf-8`. The `==` check was always false, so every streaming response crashed on `json.loads`. Since no other clients on this host use `stream: true`, they were all unaffected — which is why the symptom looked like \"one specific client breaks\".

After applying the SSE detection fix, the 500s stopped entirely on that host.

## Test plan

- [x] Deployed commits 1+2+3 on one production VM, restarted `libertai_api.service`
- [x] Direct curl to upstream confirmed `content-type: text/event-stream; charset=utf-8`
- [x] No new 500s from the affected client after the SSE fix
- [x] Non-streaming requests from other clients continue to work (observed 900+ × 200 OK after restart)
- [x] `logger.exception` output confirmed visible in `journalctl -u libertai_api.service`

## Notes

The three commits are logically independent and could be cherry-picked in any order or reviewed separately. Commit 1 is the actual bug fix and is the minimum needed to stop the bleeding; commits 2 and 3 are correctness and observability hardening discovered during the investigation.