### PR TITLE
feat: support embedding models (bge-m3)

### DIFF
--- a/data/bge-m3.json
+++ b/data/bge-m3.json
@@ -1,0 +1,8 @@
+{
+  "id": "bge-m3",
+  "type": "embedding",
+  "url": "http://localhost:8005",
+  "allowed_paths": [
+    "v1/embeddings"
+  ]
+}

--- a/src/config.py
+++ b/src/config.py
@@ -27,7 +27,14 @@ class ImageEditModelConfig(BaseModel):
     allowed_paths: list[str]
 
 
-ModelConfig = TextModelConfig | ImageModelConfig | ImageEditModelConfig
+class EmbeddingModelConfig(BaseModel):
+    type: Literal["embedding"] = "embedding"
+    id: str
+    url: str
+    allowed_paths: list[str]
+
+
+ModelConfig = TextModelConfig | ImageModelConfig | ImageEditModelConfig | EmbeddingModelConfig
 
 
 class _Config:
@@ -60,6 +67,8 @@ class _Config:
                     model_config = ImageModelConfig(**model_data)
                 elif model_data.get("type") == "image-edit":
                     model_config = ImageEditModelConfig(**model_data)
+                elif model_data.get("type") == "embedding":
+                    model_config = EmbeddingModelConfig(**model_data)
                 else:
                     model_config = TextModelConfig(**model_data)
                 self.MODEL_CONFIGS[model_config.id] = model_config

--- a/src/interfaces/usage.py
+++ b/src/interfaces/usage.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 class InferenceCallType(str, Enum):
     text = "text"
     image = "image"
+    embedding = "embedding"
 
 
 class UserContext(BaseModel):

--- a/src/proxy.py
+++ b/src/proxy.py
@@ -10,7 +10,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel
 
 from src.api_keys import KeysManager
-from src.config import ImageEditModelConfig, ImageModelConfig, TextModelConfig, config
+from src.config import EmbeddingModelConfig, ImageEditModelConfig, ImageModelConfig, TextModelConfig, config
 from src.image_generation import ImageModelManager
 from src.interfaces.usage import TextUsageFullData, UserContext
 from src.usage import report_usage_event_task, extract_usage_info_from_raw, extract_usage_info
@@ -57,8 +57,8 @@ async def proxy_health(request: Request, model_name: str):
 
     model_config = config.MODEL_CONFIGS[model_name]
 
-    # For image models, check if the pipeline is loaded
-    if not isinstance(model_config, TextModelConfig):
+    # For image models, check if the in-process pipeline is loaded
+    if isinstance(model_config, (ImageModelConfig, ImageEditModelConfig)):
         if _image_manager.is_loaded(model_name):
             return Response(
                 content=json.dumps({"status": "ok"}).encode(),
@@ -78,7 +78,7 @@ async def proxy_health(request: Request, model_name: str):
                 media_type="application/json",
             )
 
-    # For text models, proxy to llamacpp /health endpoint
+    # For text and embedding models, proxy to the llamacpp /health endpoint
     url = f"{model_config.url}/health"
 
     headers = dict(request.headers)
@@ -118,8 +118,10 @@ async def proxy_request(
 
     model_config = config.MODEL_CONFIGS[model_name]
 
-    if not isinstance(model_config, TextModelConfig):
-        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail="This endpoint is only for text models")
+    if not isinstance(model_config, (TextModelConfig, EmbeddingModelConfig)):
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST, detail="This endpoint is only for text and embedding models"
+        )
 
     if full_path not in model_config.allowed_paths:
         raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail="Invalid inference path")

--- a/src/usage.py
+++ b/src/usage.py
@@ -168,6 +168,14 @@ def extract_usage_info(data: dict[str, Any], context: UserContext) -> Usage:
             output_tokens=int(usage_data.get("completion_tokens", 0)),
             cached_tokens=0,
         )
+    elif context.endpoint == "v1/embeddings":
+        # Embeddings are input-only: usage carries prompt_tokens (== total_tokens), no completion.
+        usage_data = data.get("usage", {})
+        return Usage(
+            input_tokens=int(usage_data.get("prompt_tokens", 0)),
+            output_tokens=0,
+            cached_tokens=0,
+        )
     elif context.endpoint == "completions":
         return Usage(
             input_tokens=int(data.get("tokens_evaluated", 0)),


### PR DESCRIPTION
## Summary
Adds **embedding model** support to the model-instance proxy, so a model whose local llama.cpp server exposes `/v1/embeddings` (e.g. **bge-m3**) can be served through the LibertAI stack like text/image models.

## Changes
- `config.py`: new `EmbeddingModelConfig` (`type: "embedding"`, `url`, `allowed_paths`) + loader branch.
- `proxy.py`: embedding models go through the text-style health + proxy path (real HTTP server with `url`), not the in-process image manager.
- `usage.py`: `v1/embeddings` usage extraction — input tokens only (no completion).
- `interfaces/usage.py`: add `InferenceCallType.embedding`.
- `data/bge-m3.json`: bge-m3 config (`http://localhost:8005`, `v1/embeddings`).

## Verification
- `ruff check` ✓, `mypy` ✓
- Deployed on test-6000-ada-1; `/health/bge-m3` proxies OK to the running llama-server.

Part of cross-repo embedding support (libertai-api x402 pricing, libertai-inference `embedding` pricing kind, libertai-docs).
