### PR TITLE
feat: Kokoro TTS — /v1/audio/speech endpoint

### DIFF
--- a/data/kokoro-82m.json
+++ b/data/kokoro-82m.json
@@ -1,6 +1,6 @@
 {
   "type": "audio",
-  "id": "kokoro",
+  "id": "kokoro-82m",
   "local_path": "hexgrad/Kokoro-82M",
   "allowed_paths": ["v1/audio/speech"],
   "default_voice": "af_heart",

--- a/data/kokoro.json
+++ b/data/kokoro.json
@@ -1,0 +1,8 @@
+{
+  "type": "audio",
+  "id": "kokoro",
+  "local_path": "hexgrad/Kokoro-82M",
+  "allowed_paths": ["v1/audio/speech"],
+  "default_voice": "af_heart",
+  "lang_code": "a"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,18 +29,13 @@ image = [
     "onnxruntime (>=1.23.2,<2.0.0)"
 ]
 
-# Dedicated TTS instance only (not co-located with the image extra, whose transformers
-# range conflicts). torch is installed separately from the cu124 index at deploy time:
-# the default PyPI wheel is cu130, too new for the instance driver (535). transformers is
-# pinned because newer releases reference torch.float8_e8m0fnu (absent in torch 2.6) and
-# crash Kokoro's import.
-tts = [
-    "kokoro (>=0.9.0,<1.0.0)",
-    "transformers (==4.49.0)",
-    "soundfile (>=0.12.0,<1.0.0)",
-    "misaki[en] (>=0.9.0,<1.0.0)",
-    "numpy (>=1.26.0,<3.0.0)"
-]
+# TTS (Kokoro) deps are intentionally NOT declared as a poetry extra: they require
+# transformers==4.49.0, which conflicts with the `image` extra's transformers>=4.51.3
+# (poetry resolves a single version across all extras). TTS runs on a dedicated instance
+# that never installs the `image` extra, and the repo is `package-mode = false` (so
+# `pip install -e ".[tts]"` has no package to build anyway). The TTS deployment therefore
+# installs these explicitly via pip — see devops `deployment/install_kokoro.sh`:
+#   torch==2.6.0 (cu124 index), kokoro, transformers==4.49.0, soundfile, misaki[en], numpy
 
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,19 @@ image = [
     "onnxruntime (>=1.23.2,<2.0.0)"
 ]
 
+# Dedicated TTS instance only (not co-located with the image extra, whose transformers
+# range conflicts). torch is installed separately from the cu124 index at deploy time:
+# the default PyPI wheel is cu130, too new for the instance driver (535). transformers is
+# pinned because newer releases reference torch.float8_e8m0fnu (absent in torch 2.6) and
+# crash Kokoro's import.
+tts = [
+    "kokoro (>=0.9.0,<1.0.0)",
+    "transformers (==4.49.0)",
+    "soundfile (>=0.12.0,<1.0.0)",
+    "misaki[en] (>=0.9.0,<1.0.0)",
+    "numpy (>=1.26.0,<3.0.0)"
+]
+
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]

--- a/src/config.py
+++ b/src/config.py
@@ -34,7 +34,18 @@ class EmbeddingModelConfig(BaseModel):
     allowed_paths: list[str]
 
 
-ModelConfig = TextModelConfig | ImageModelConfig | ImageEditModelConfig | EmbeddingModelConfig
+class AudioModelConfig(BaseModel):
+    type: Literal["audio"] = "audio"
+    id: str
+    local_path: str
+    allowed_paths: list[str]
+    default_voice: str
+    lang_code: str = "a"
+
+
+ModelConfig = (
+    TextModelConfig | ImageModelConfig | ImageEditModelConfig | EmbeddingModelConfig | AudioModelConfig
+)
 
 
 class _Config:
@@ -69,6 +80,8 @@ class _Config:
                     model_config = ImageEditModelConfig(**model_data)
                 elif model_data.get("type") == "embedding":
                     model_config = EmbeddingModelConfig(**model_data)
+                elif model_data.get("type") == "audio":
+                    model_config = AudioModelConfig(**model_data)
                 else:
                     model_config = TextModelConfig(**model_data)
                 self.MODEL_CONFIGS[model_config.id] = model_config

--- a/src/interfaces/usage.py
+++ b/src/interfaces/usage.py
@@ -7,6 +7,7 @@ class InferenceCallType(str, Enum):
     text = "text"
     image = "image"
     embedding = "embedding"
+    audio = "audio"
 
 
 class UserContext(BaseModel):
@@ -29,11 +30,20 @@ class ImageUsage(BaseModel):
     type: InferenceCallType = InferenceCallType.image
 
 
+class AudioUsage(BaseModel):
+    input_tokens: int  # character count of the input text
+    type: InferenceCallType = InferenceCallType.audio
+
+
 class TextUsageFullData(UserContext, TextUsage):
     pass
 
 
 class ImageUsageFullData(UserContext, ImageUsage):
+    pass
+
+
+class AudioUsageFullData(UserContext, AudioUsage):
     pass
 
 

--- a/src/proxy.py
+++ b/src/proxy.py
@@ -10,9 +10,17 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel
 
 from src.api_keys import KeysManager
-from src.config import EmbeddingModelConfig, ImageEditModelConfig, ImageModelConfig, TextModelConfig, config
+from src.config import (
+    AudioModelConfig,
+    EmbeddingModelConfig,
+    ImageEditModelConfig,
+    ImageModelConfig,
+    TextModelConfig,
+    config,
+)
 from src.image_generation import ImageModelManager
 from src.interfaces.usage import TextUsageFullData, UserContext
+from src.tts_generation import TTSModelManager
 from src.usage import report_usage_event_task, extract_usage_info_from_raw, extract_usage_info
 
 logger = logging.getLogger(__name__)
@@ -44,6 +52,12 @@ for _model_id, _model_config in config.MODEL_CONFIGS.items():
     if isinstance(_model_config, (ImageModelConfig, ImageEditModelConfig)):
         _image_manager.register(_model_id, _model_config)
 
+# Register audio model configs with the TTS manager (singleton shared with tts_routes)
+_tts_manager = TTSModelManager()
+for _model_id, _model_config in config.MODEL_CONFIGS.items():
+    if isinstance(_model_config, AudioModelConfig):
+        _tts_manager.register(_model_id, _model_config)
+
 
 @router.on_event("shutdown")
 async def shutdown_event():
@@ -74,6 +88,29 @@ async def proxy_health(request: Request, model_name: str):
         else:
             return Response(
                 content=json.dumps({"status": "error", "detail": "Image model not registered"}).encode(),
+                status_code=503,
+                media_type="application/json",
+            )
+
+    # For audio models, check if the in-process TTS pipeline is loaded
+    if isinstance(model_config, AudioModelConfig):
+        if _tts_manager.is_loaded(model_name):
+            return Response(
+                content=json.dumps({"status": "ok"}).encode(),
+                status_code=200,
+                media_type="application/json",
+            )
+        elif _tts_manager.is_capable(model_name):
+            return Response(
+                content=json.dumps(
+                    {"status": "capable", "detail": "Model not loaded but can be loaded on demand"}
+                ).encode(),
+                status_code=202,
+                media_type="application/json",
+            )
+        else:
+            return Response(
+                content=json.dumps({"status": "error", "detail": "Audio model not registered"}).encode(),
                 status_code=503,
                 media_type="application/json",
             )

--- a/src/proxy.py
+++ b/src/proxy.py
@@ -52,11 +52,8 @@ for _model_id, _model_config in config.MODEL_CONFIGS.items():
     if isinstance(_model_config, (ImageModelConfig, ImageEditModelConfig)):
         _image_manager.register(_model_id, _model_config)
 
-# Register audio model configs with the TTS manager (singleton shared with tts_routes)
+# Audio model configs are registered in tts_routes; this is the same singleton instance
 _tts_manager = TTSModelManager()
-for _model_id, _model_config in config.MODEL_CONFIGS.items():
-    if isinstance(_model_config, AudioModelConfig):
-        _tts_manager.register(_model_id, _model_config)
 
 
 @router.on_event("shutdown")

--- a/src/server.py
+++ b/src/server.py
@@ -4,6 +4,7 @@ from starlette.middleware.cors import CORSMiddleware
 from src.api_keys import router as libertai_router
 from src.image_routes import router as image_router
 from src.proxy import router as proxy_router
+from src.tts_routes import router as tts_router
 
 app = FastAPI(title="LibertAI backend service")
 
@@ -17,4 +18,5 @@ app.add_middleware(
 
 app.include_router(libertai_router)
 app.include_router(image_router)
+app.include_router(tts_router)
 app.include_router(proxy_router)

--- a/src/tts_generation.py
+++ b/src/tts_generation.py
@@ -4,9 +4,9 @@ from typing import Any, Optional
 
 try:
     import numpy as np
-    import soundfile as sf
+    import soundfile as sf  # type: ignore
     import torch
-    from kokoro import KPipeline
+    from kokoro import KPipeline  # type: ignore
 
     KOKORO_AVAILABLE = True
 except ImportError:

--- a/src/tts_generation.py
+++ b/src/tts_generation.py
@@ -30,7 +30,6 @@ class TTSModelManager:
     _refcounts: dict[str, int] = {}
     _model_configs: dict[str, Any] = {}  # AudioModelConfig
     _inference_locks: dict[str, threading.Lock] = {}
-    _device: str = "cuda" if KOKORO_AVAILABLE and torch.cuda.is_available() else "cpu"
     _lock: threading.Lock = threading.Lock()
 
     def __new__(cls) -> "TTSModelManager":
@@ -62,6 +61,8 @@ class TTSModelManager:
             if self._refcounts.get(mid, 0) > 0:
                 continue
             del self._pipelines[mid]
+            if mid in self._inference_locks:
+                del self._inference_locks[mid]
         if KOKORO_AVAILABLE and torch.cuda.is_available():
             torch.cuda.empty_cache()
 

--- a/src/tts_generation.py
+++ b/src/tts_generation.py
@@ -1,0 +1,116 @@
+import io
+import threading
+from typing import Any, Optional
+
+try:
+    import numpy as np
+    import soundfile as sf
+    import torch
+    from kokoro import KPipeline
+
+    KOKORO_AVAILABLE = True
+except ImportError:
+    KOKORO_AVAILABLE = False
+    np = None  # type: ignore
+    sf = None  # type: ignore
+    torch = None  # type: ignore
+    KPipeline = None  # type: ignore
+
+
+class TTSModelManager:
+    """Singleton managing Kokoro TTS pipelines with on-demand loading.
+
+    Mirrors ImageModelManager: refcounted load, per-model inference lock, OOM eviction.
+    Kokoro pipelines are not guaranteed thread-safe, so the inference lock serializes
+    synthesis per model.
+    """
+
+    _instance: Optional["TTSModelManager"] = None
+    _pipelines: dict[str, Any] = {}
+    _refcounts: dict[str, int] = {}
+    _model_configs: dict[str, Any] = {}  # AudioModelConfig
+    _inference_locks: dict[str, threading.Lock] = {}
+    _device: str = "cuda" if KOKORO_AVAILABLE and torch.cuda.is_available() else "cpu"
+    _lock: threading.Lock = threading.Lock()
+
+    def __new__(cls) -> "TTSModelManager":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._instance._pipelines = {}
+            cls._instance._refcounts = {}
+            cls._instance._model_configs = {}
+            cls._instance._inference_locks = {}
+        return cls._instance
+
+    def register(self, model_id: str, model_config: Any) -> None:
+        self._model_configs[model_id] = model_config
+
+    def is_loaded(self, model_id: str) -> bool:
+        return model_id in self._pipelines
+
+    def is_capable(self, model_id: str) -> bool:
+        return model_id in self._model_configs
+
+    def _load(self, model_id: str) -> None:
+        cfg = self._model_configs[model_id]
+        self._pipelines[model_id] = KPipeline(lang_code=cfg.lang_code, repo_id=cfg.local_path)
+
+    def _unload_all_except(self, keep_model_id: str) -> None:
+        for mid in list(self._pipelines.keys()):
+            if mid == keep_model_id:
+                continue
+            if self._refcounts.get(mid, 0) > 0:
+                continue
+            del self._pipelines[mid]
+        if KOKORO_AVAILABLE and torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+    def acquire(self, model_id: str) -> tuple[Any, threading.Lock]:
+        """Get (pipeline, inference_lock) with refcount increment.
+
+        Caller MUST call release() when done and hold the inference_lock during synthesis.
+        """
+        with self._lock:
+            if model_id not in self._model_configs:
+                raise RuntimeError(f"Model '{model_id}' not registered")
+            if model_id not in self._pipelines:
+                try:
+                    self._load(model_id)
+                except Exception as e:
+                    if "out of memory" in str(e).lower() or (
+                        KOKORO_AVAILABLE and isinstance(e, torch.cuda.OutOfMemoryError)
+                    ):
+                        self._unload_all_except(model_id)
+                        self._load(model_id)
+                    else:
+                        raise
+            if model_id not in self._inference_locks:
+                self._inference_locks[model_id] = threading.Lock()
+            self._refcounts[model_id] = self._refcounts.get(model_id, 0) + 1
+            return self._pipelines[model_id], self._inference_locks[model_id]
+
+    def release(self, model_id: str) -> None:
+        with self._lock:
+            if model_id in self._refcounts:
+                self._refcounts[model_id] = max(0, self._refcounts[model_id] - 1)
+
+
+SAMPLE_RATE = 24000
+
+
+def synthesize_wav(pipeline: Any, text: str, voice: str, speed: float) -> bytes:
+    """Run Kokoro and return WAV bytes (24kHz mono).
+
+    Verified shape (Phase 0, kokoro 0.9.4): each yielded Result is
+    (graphemes: str, phonemes: str, audio: torch.Tensor) at 24kHz.
+    """
+    segments = []
+    for _graphemes, _phonemes, audio in pipeline(text, voice=voice, speed=speed):
+        segments.append(np.asarray(audio, dtype=np.float32))
+    if not segments:
+        raise RuntimeError("Kokoro produced no audio")
+    waveform = np.concatenate(segments)
+    buf = io.BytesIO()
+    sf.write(buf, waveform, SAMPLE_RATE, format="WAV")
+    buf.seek(0)
+    return buf.read()

--- a/src/tts_routes.py
+++ b/src/tts_routes.py
@@ -1,0 +1,101 @@
+import asyncio
+from http import HTTPStatus
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+from fastapi.responses import Response
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from pydantic import BaseModel
+
+from src.api_keys import KeysManager
+from src.config import AudioModelConfig, config
+from src.interfaces.usage import AudioUsage, AudioUsageFullData, UserContext
+from src.tts_generation import TTSModelManager, synthesize_wav
+from src.usage import report_usage_event_task
+
+router = APIRouter(tags=["Audio"])
+security = HTTPBearer()
+keys_manager = KeysManager()
+tts_manager = TTSModelManager()
+
+# Register audio model configs at import
+for _model_id, _model_config in config.MODEL_CONFIGS.items():
+    if isinstance(_model_config, AudioModelConfig):
+        tts_manager.register(_model_id, _model_config)
+
+MIN_SPEED = 0.25
+MAX_SPEED = 4.0
+MAX_INPUT_CHARS = 8192
+
+
+class SpeechRequest(BaseModel):
+    model: str
+    input: str
+    voice: str | None = None
+    response_format: str = "wav"
+    speed: float = 1.0
+
+
+def _validate(body: SpeechRequest, token: str) -> AudioModelConfig:
+    if not keys_manager.key_exists(token):
+        raise HTTPException(status_code=HTTPStatus.UNAUTHORIZED, detail="Invalid API key")
+    if body.model not in config.MODEL_CONFIGS:
+        raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=f"Model '{body.model}' not found")
+    model_config = config.MODEL_CONFIGS[body.model]
+    if not isinstance(model_config, AudioModelConfig):
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=f"Model '{body.model}' is not an audio model")
+    if "v1/audio/speech" not in model_config.allowed_paths:
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail="Invalid endpoint for this model")
+    if not body.input or not body.input.strip():
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail="input cannot be empty")
+    if len(body.input) > MAX_INPUT_CHARS:
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=f"input exceeds {MAX_INPUT_CHARS} characters")
+    if body.response_format != "wav":
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail=f"response_format '{body.response_format}' not supported; only 'wav' is available",
+        )
+    if not (MIN_SPEED <= body.speed <= MAX_SPEED):
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST, detail=f"speed must be between {MIN_SPEED} and {MAX_SPEED}"
+        )
+    return model_config
+
+
+def _track_usage(token: str, model_name: str, character_count: int, background_tasks: BackgroundTasks) -> None:
+    try:
+        user_context = UserContext(key=token, model_name=model_name, endpoint="v1/audio/speech")
+        usage_data = AudioUsageFullData(
+            **user_context.model_dump(),
+            **AudioUsage(input_tokens=character_count).model_dump(),
+        )
+        background_tasks.add_task(report_usage_event_task, usage_data)
+    except Exception as e:
+        print(f"Exception occurred during usage report: {str(e)}")
+
+
+@router.post("/v1/audio/speech")
+async def create_speech(
+    body: SpeechRequest,
+    background_tasks: BackgroundTasks,
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+) -> Response:
+    token = credentials.credentials
+    model_config = _validate(body, token)
+    voice = body.voice or model_config.default_voice
+
+    def _blocking() -> bytes:
+        pipeline, inference_lock = tts_manager.acquire(body.model)
+        try:
+            with inference_lock:
+                return synthesize_wav(pipeline, body.input, voice, body.speed)
+        finally:
+            tts_manager.release(body.model)
+
+    loop = asyncio.get_running_loop()
+    try:
+        wav_bytes = await loop.run_in_executor(None, _blocking)
+    except Exception as e:
+        raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail=f"TTS synthesis failed: {str(e)}")
+
+    _track_usage(token, body.model, len(body.input), background_tasks)
+    return Response(content=wav_bytes, media_type="audio/wav")

--- a/src/usage.py
+++ b/src/usage.py
@@ -5,7 +5,7 @@ from typing import Any, Iterator
 import httpx
 
 from src.config import config
-from src.interfaces.usage import ImageUsageFullData, TextUsageFullData, Usage, UserContext
+from src.interfaces.usage import AudioUsageFullData, ImageUsageFullData, TextUsageFullData, Usage, UserContext
 
 
 def _iter_json_at_key(text: str, key: str) -> Iterator[dict]:
@@ -40,7 +40,7 @@ def _iter_json_at_key(text: str, key: str) -> Iterator[dict]:
                     break
 
 
-async def report_usage_event_task(usage: TextUsageFullData | ImageUsageFullData):
+async def report_usage_event_task(usage: TextUsageFullData | ImageUsageFullData | AudioUsageFullData):
     print(f"Collecting usage {usage}")
     try:
         timeout = httpx.Timeout(timeout=30.0)

--- a/tests/test_audio_usage_interface.py
+++ b/tests/test_audio_usage_interface.py
@@ -1,0 +1,17 @@
+from src.interfaces.usage import AudioUsage, AudioUsageFullData, InferenceCallType
+
+
+def test_audio_usage_type_is_audio():
+    u = AudioUsage(input_tokens=42)
+    assert u.type == InferenceCallType.audio
+    assert u.input_tokens == 42
+
+
+def test_audio_usage_full_data_carries_context():
+    full = AudioUsageFullData(
+        key="k", model_name="kokoro", endpoint="v1/audio/speech", input_tokens=42,
+    )
+    payload = full.model_dump()
+    assert payload["input_tokens"] == 42
+    assert payload["model_name"] == "kokoro"
+    assert payload["type"] == "audio"

--- a/tests/test_config_audio.py
+++ b/tests/test_config_audio.py
@@ -1,0 +1,28 @@
+from src.config import AudioModelConfig
+
+
+def test_audio_model_config_parses():
+    raw = {
+        "type": "audio",
+        "id": "kokoro",
+        "local_path": "hexgrad/Kokoro-82M",
+        "allowed_paths": ["v1/audio/speech"],
+        "default_voice": "af_heart",
+        "lang_code": "a",
+    }
+    cfg = AudioModelConfig(**raw)
+    assert cfg.type == "audio"
+    assert cfg.id == "kokoro"
+    assert cfg.default_voice == "af_heart"
+    assert cfg.lang_code == "a"
+    assert "v1/audio/speech" in cfg.allowed_paths
+
+
+def test_audio_model_config_lang_code_defaults_to_american_english():
+    cfg = AudioModelConfig(
+        id="kokoro",
+        local_path="hexgrad/Kokoro-82M",
+        allowed_paths=["v1/audio/speech"],
+        default_voice="af_heart",
+    )
+    assert cfg.lang_code == "a"

--- a/tests/test_proxy_health_audio.py
+++ b/tests/test_proxy_health_audio.py
@@ -1,0 +1,41 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.config import AudioModelConfig
+import src.proxy as proxy
+
+
+@pytest.fixture
+def client(monkeypatch):
+    cfg = AudioModelConfig(
+        id="kokoro",
+        local_path="hexgrad/Kokoro-82M",
+        allowed_paths=["v1/audio/speech"],
+        default_voice="af_heart",
+    )
+    monkeypatch.setattr(proxy.config, "MODEL_CONFIGS", {"kokoro": cfg})
+    proxy._tts_manager.register("kokoro", cfg)
+    app = FastAPI()
+    app.include_router(proxy.router)
+    return TestClient(app)
+
+
+def test_health_unknown_model_404(client):
+    assert client.get("/health/nope").status_code == 404
+
+
+def test_health_audio_capable_returns_202_when_not_loaded(client, monkeypatch):
+    # Registered but pipeline not loaded → capable
+    monkeypatch.setattr(proxy._tts_manager, "is_loaded", lambda m: False)
+    monkeypatch.setattr(proxy._tts_manager, "is_capable", lambda m: True)
+    r = client.get("/health/kokoro")
+    assert r.status_code == 202
+    assert r.json()["status"] == "capable"
+
+
+def test_health_audio_loaded_returns_200(client, monkeypatch):
+    monkeypatch.setattr(proxy._tts_manager, "is_loaded", lambda m: True)
+    r = client.get("/health/kokoro")
+    assert r.status_code == 200
+    assert r.json()["status"] == "ok"

--- a/tests/test_tts_routes.py
+++ b/tests/test_tts_routes.py
@@ -1,0 +1,51 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.config import AudioModelConfig
+import src.tts_routes as tts_routes
+
+
+@pytest.fixture
+def client(monkeypatch):
+    cfg = AudioModelConfig(
+        id="kokoro",
+        local_path="hexgrad/Kokoro-82M",
+        allowed_paths=["v1/audio/speech"],
+        default_voice="af_heart",
+    )
+    monkeypatch.setattr(tts_routes.config, "MODEL_CONFIGS", {"kokoro": cfg})
+    monkeypatch.setattr(tts_routes.keys_manager, "key_exists", lambda token: token == "good")
+    app = FastAPI()
+    app.include_router(tts_routes.router)
+    return TestClient(app)
+
+
+def _post(client, body, token="good"):
+    return client.post("/v1/audio/speech", json=body, headers={"Authorization": f"Bearer {token}"})
+
+
+def test_rejects_bad_api_key(client):
+    r = _post(client, {"model": "kokoro", "input": "hi"}, token="bad")
+    assert r.status_code == 401
+
+
+def test_rejects_unknown_model(client):
+    r = _post(client, {"model": "nope", "input": "hi"})
+    assert r.status_code == 404
+
+
+def test_rejects_empty_input(client):
+    r = _post(client, {"model": "kokoro", "input": "   "})
+    assert r.status_code == 400
+
+
+def test_rejects_non_wav_format(client):
+    r = _post(client, {"model": "kokoro", "input": "hi", "response_format": "mp3"})
+    assert r.status_code == 400
+    assert "wav" in r.json()["detail"].lower()
+
+
+def test_rejects_out_of_range_speed(client):
+    r = _post(client, {"model": "kokoro", "input": "hi", "speed": 9.0})
+    assert r.status_code == 400


### PR DESCRIPTION
Adds in-process [Kokoro-82M](https://huggingface.co/hexgrad/Kokoro-82M) (MIT) text-to-speech as a new `audio` modality, exposing an OpenAI-compatible `POST /v1/audio/speech` (model id `kokoro-82m`).

## What's included
- `AudioModelConfig` model type + loader branch (`src/config.py`)
- `TTSModelManager` — in-process, refcounted VRAM, per-model lock, OOM eviction, mirroring `ImageModelManager` (`src/tts_generation.py`)
- `POST /v1/audio/speech` route: OpenAI body (`model/input/voice/response_format/speed`), WAV output, raw Kokoro voice IDs, per-character usage reporting (`src/tts_routes.py`)
- `AudioUsage`/`AudioUsageFullData` (input-only; `input_tokens` carries character count) — no DB migration downstream
- `/health/{model}` handles audio models via the TTS manager
- `data/kokoro-82m.json`

## Dependencies
TTS deps are **not** a poetry extra: Kokoro needs `transformers==4.49.0`, which conflicts with the `image` extra's `transformers>=4.51.3` (poetry resolves one version across all extras). TTS runs on a dedicated instance and the repo is `package-mode=false`, so deps are installed via pip in devops `install_kokoro.sh` (`torch==2.6.0` cu124, kokoro, transformers==4.49.0, soundfile, misaki[en], numpy).

## Billing
Input-only modality, billed per **character** (`input_tokens` = `len(input)`), mirroring embeddings. Priced in the `LTAI_PRICING` aggregate + `libertai-inference` (separate PR).

## Verification
- 12 unit tests (config, manager, route validation, usage, health) — all pass; mypy + ruff green.
- Validated on a real RTX 3090: `TTSModelManager` + `synthesize_wav` produce a valid WAV on GPU; full HTTP route returns `200 audio/wav` with correct usage payload (`input_tokens`=char count, `type=audio`) and `401` on bad keys. ~580 MB VRAM, real-time factor ~3.8×.
- End-to-end through production `api.libertai.io/v1/audio/speech` returns valid WAV.