### PR TITLE
Parse cached_tokens from vLLM usage

### DIFF
--- a/src/usage.py
+++ b/src/usage.py
@@ -8,6 +8,18 @@ from src.config import config
 from src.interfaces.usage import AudioUsageFullData, ImageUsageFullData, TextUsageFullData, Usage, UserContext
 
 
+def _extract_cached_tokens(usage_json: dict) -> int:
+    """Read the prefix-cache hit count from an OpenAI/vLLM usage object.
+
+    vLLM only emits `usage.prompt_tokens_details.cached_tokens` when the server runs with
+    `--enable-prompt-tokens-details`; otherwise the field is absent/null and we report 0.
+    """
+    details = usage_json.get("prompt_tokens_details")
+    if isinstance(details, dict):
+        return int(details.get("cached_tokens") or 0)
+    return 0
+
+
 def _iter_json_at_key(text: str, key: str) -> Iterator[dict]:
     """Yield each `"key": {...}` value as a parsed dict. Handles nested braces."""
     pattern = re.compile(rf'"{re.escape(key)}"\s*:\s*(?=\{{)')
@@ -111,7 +123,7 @@ def extract_usage_info_from_raw(raw_data: bytes, context: UserContext) -> Usage:
                 return Usage(
                     input_tokens=int(usage_json.get("prompt_tokens", 0)),
                     output_tokens=int(usage_json.get("completion_tokens", 0)),
-                    cached_tokens=0,
+                    cached_tokens=_extract_cached_tokens(usage_json),
                 )
 
         # llama.cpp: usage is embedded as a "timings" object in the final chunk
@@ -166,7 +178,7 @@ def extract_usage_info(data: dict[str, Any], context: UserContext) -> Usage:
         return Usage(
             input_tokens=int(usage_data.get("prompt_tokens", 0)),
             output_tokens=int(usage_data.get("completion_tokens", 0)),
-            cached_tokens=0,
+            cached_tokens=_extract_cached_tokens(usage_data),
         )
     elif context.endpoint == "v1/embeddings":
         # Embeddings are input-only: usage carries prompt_tokens (== total_tokens), no completion.

--- a/tests/test_usage_cached_tokens.py
+++ b/tests/test_usage_cached_tokens.py
@@ -1,0 +1,48 @@
+import json
+
+from src.interfaces.usage import UserContext
+from src.usage import extract_usage_info, extract_usage_info_from_raw
+
+CTX = UserContext(key="k", model_name="glm-5.2", endpoint="v1/chat/completions")
+
+
+def test_non_stream_with_cached_tokens():
+    data = {
+        "usage": {
+            "prompt_tokens": 100,
+            "completion_tokens": 10,
+            "prompt_tokens_details": {"cached_tokens": 64},
+        }
+    }
+    u = extract_usage_info(data, CTX)
+    assert (u.input_tokens, u.output_tokens, u.cached_tokens) == (100, 10, 64)
+
+
+def test_non_stream_details_null():
+    data = {"usage": {"prompt_tokens": 100, "completion_tokens": 10, "prompt_tokens_details": None}}
+    assert extract_usage_info(data, CTX).cached_tokens == 0
+
+
+def test_non_stream_details_absent():
+    data = {"usage": {"prompt_tokens": 100, "completion_tokens": 10}}
+    assert extract_usage_info(data, CTX).cached_tokens == 0
+
+
+def test_stream_with_cached_tokens():
+    chunk = {
+        "choices": [{"delta": {}}],
+        "usage": {
+            "prompt_tokens": 100,
+            "completion_tokens": 10,
+            "prompt_tokens_details": {"cached_tokens": 64},
+        },
+    }
+    raw = (f"data: {json.dumps(chunk)}\n\ndata: [DONE]\n\n").encode()
+    u = extract_usage_info_from_raw(raw, CTX)
+    assert (u.input_tokens, u.output_tokens, u.cached_tokens) == (100, 10, 64)
+
+
+def test_stream_without_cached_tokens():
+    chunk = {"choices": [{"delta": {}}], "usage": {"prompt_tokens": 100, "completion_tokens": 10}}
+    raw = (f"data: {json.dumps(chunk)}\n\n").encode()
+    assert extract_usage_info_from_raw(raw, CTX).cached_tokens == 0


### PR DESCRIPTION
## What

Extract `usage.prompt_tokens_details.cached_tokens` (vLLM prefix-cache hits) on the chat/completions paths instead of hardcoding `cached_tokens=0`.

## Why

vLLM (with `--enable-prompt-tokens-details`) reports how many prompt tokens were served from the prefix cache. We were dropping that, so the billing backend always saw 0 and could never discount cached input.

## Changes

- Add `_extract_cached_tokens()` helper (returns 0 when the field is absent/null).
- Wire it into `extract_usage_info` (non-streaming) and `extract_usage_info_from_raw` (streaming).
- Tests.

## Notes

- `cached_tokens` is a subset of `prompt_tokens`, sent alongside the unchanged input/output counts.
- Pairs with libertai-inference PR that bills cached input at a dedicated rate.