### PR TITLE
feat: report cache hits on Anthropic /v1/messages usage

### DIFF
--- a/src/usage.py
+++ b/src/usage.py
@@ -20,6 +20,15 @@ def _extract_cached_tokens(usage_json: dict) -> int:
     return 0
 
 
+def _anthropic_cache_tokens(usage_json: dict) -> tuple[int, int]:
+    # Anthropic usage splits cache hits out of input_tokens (vLLM >=0.24); callers add these
+    # back to recover the OpenAI-style total. Absent on older vLLM -> (0, 0).
+    return (
+        int(usage_json.get("cache_read_input_tokens") or 0),
+        int(usage_json.get("cache_creation_input_tokens") or 0),
+    )
+
+
 def _iter_json_at_key(text: str, key: str) -> Iterator[dict]:
     """Yield each `"key": {...}` value as a parsed dict. Handles nested braces."""
     pattern = re.compile(rf'"{re.escape(key)}"\s*:\s*(?=\{{)')
@@ -83,19 +92,23 @@ def extract_usage_info_from_raw(raw_data: bytes, context: UserContext) -> Usage:
         raise ValueError("Unable to decode raw response content")
 
     if context.endpoint == "v1/messages":
-        # Claude/Anthropic streaming: `message_start` carries initial usage (output_tokens=0
-        # or 1) and `message_delta` carries the final cumulative usage. Both report
-        # input_tokens, so SUMMING would double-count. Take the max across all events.
-        input_tokens = 0
-        output_tokens = 0
+        # message_start and message_delta both carry cumulative usage, so max (not sum).
+        input_tokens = output_tokens = cache_read = cache_creation = 0
         seen = False
         for usage_json in _iter_json_at_key(text, "usage"):
             seen = True
             input_tokens = max(input_tokens, int(usage_json.get("input_tokens", 0)))
             output_tokens = max(output_tokens, int(usage_json.get("output_tokens", 0)))
+            cr, cc = _anthropic_cache_tokens(usage_json)
+            cache_read = max(cache_read, cr)
+            cache_creation = max(cache_creation, cc)
 
         if seen:
-            return Usage(input_tokens=input_tokens, output_tokens=output_tokens, cached_tokens=0)
+            return Usage(
+                input_tokens=input_tokens + cache_read + cache_creation,
+                output_tokens=output_tokens,
+                cached_tokens=cache_read,
+            )
 
         raise ValueError("No usage data found in Claude API streaming response")
 
@@ -158,12 +171,12 @@ def extract_usage_info(data: dict[str, Any], context: UserContext) -> Usage:
     """
 
     if context.endpoint == "v1/messages":
-        # Claude API format: usage.input_tokens and usage.output_tokens
-        usage_data: dict = data.get("usage", {})
+        usage_data = data.get("usage", {})
+        cache_read, cache_creation = _anthropic_cache_tokens(usage_data)
         return Usage(
-            input_tokens=int(usage_data.get("input_tokens", 0)),
+            input_tokens=int(usage_data.get("input_tokens", 0)) + cache_read + cache_creation,
             output_tokens=int(usage_data.get("output_tokens", 0)),
-            cached_tokens=0,
+            cached_tokens=cache_read,
         )
     elif context.endpoint == "v1/responses":
         # Responses API format: usage at top level with input_tokens, output_tokens

--- a/tests/test_usage_cached_tokens.py
+++ b/tests/test_usage_cached_tokens.py
@@ -46,3 +46,34 @@ def test_stream_without_cached_tokens():
     chunk = {"choices": [{"delta": {}}], "usage": {"prompt_tokens": 100, "completion_tokens": 10}}
     raw = (f"data: {json.dumps(chunk)}\n\n").encode()
     assert extract_usage_info_from_raw(raw, CTX).cached_tokens == 0
+
+
+ANTHROPIC_CTX = UserContext(key="k", model_name="glm-5.2", endpoint="v1/messages")
+
+
+def test_anthropic_non_stream_with_cache():
+    data = {"usage": {"input_tokens": 36, "output_tokens": 10, "cache_read_input_tokens": 64}}
+    u = extract_usage_info(data, ANTHROPIC_CTX)
+    assert (u.input_tokens, u.output_tokens, u.cached_tokens) == (100, 10, 64)
+
+
+def test_anthropic_non_stream_legacy_no_cache_fields():
+    data = {"usage": {"input_tokens": 100, "output_tokens": 10}}
+    u = extract_usage_info(data, ANTHROPIC_CTX)
+    assert (u.input_tokens, u.output_tokens, u.cached_tokens) == (100, 10, 0)
+
+
+def test_anthropic_stream_with_cache():
+    start = {"type": "message_start", "message": {"usage": {"input_tokens": 36, "output_tokens": 0, "cache_read_input_tokens": 64}}}
+    delta = {"type": "message_delta", "usage": {"input_tokens": 36, "output_tokens": 10, "cache_read_input_tokens": 64}}
+    raw = (f"event: message_start\ndata: {json.dumps(start)}\n\nevent: message_delta\ndata: {json.dumps(delta)}\n\n").encode()
+    u = extract_usage_info_from_raw(raw, ANTHROPIC_CTX)
+    assert (u.input_tokens, u.output_tokens, u.cached_tokens) == (100, 10, 64)
+
+
+def test_anthropic_stream_legacy_no_cache_fields():
+    start = {"type": "message_start", "message": {"usage": {"input_tokens": 100, "output_tokens": 0}}}
+    delta = {"type": "message_delta", "usage": {"input_tokens": 100, "output_tokens": 10}}
+    raw = (f"event: message_start\ndata: {json.dumps(start)}\n\nevent: message_delta\ndata: {json.dumps(delta)}\n\n").encode()
+    u = extract_usage_info_from_raw(raw, ANTHROPIC_CTX)
+    assert (u.input_tokens, u.output_tokens, u.cached_tokens) == (100, 10, 0)


### PR DESCRIPTION
## Problem
Claude Code (and any Anthropic `/v1/messages` client) was billed with `cached_tokens=0` on every call, so repeated context was charged at the full input rate instead of the cached rate — ~3× overcharge on cache-heavy sessions.

Root cause is two layers:
- **vLLM 0.23.0** on the GLM-5.2 box never surfaces prefix-cache hits on the `/v1/messages` path (fixed upstream in **0.24.0**, PR vllm-project/vllm#40912).
- The gateway's `v1/messages` usage extraction hardcoded `cached_tokens=0`.

## This change (gateway only)
Reads vLLM 0.24's Anthropic-style cache fields and reconstructs the OpenAI-style shape libertai-inference already bills on:
- `input_tokens` = `input_tokens + cache_read + cache_creation` (total, cached included)
- `cached_tokens` = `cache_read_input_tokens` (the discounted subset)

Applied to both streaming and non-streaming paths. libertai-inference is untouched.

## Safety
Forward/backward compatible: on the current 0.23.0 (no cache fields) it collapses to the previous behavior (`cached=0`), so this can ship before or after the vLLM upgrade without changing anything until vLLM emits the fields.

## Follow-up (not in this PR)
- Upgrade GLM-5.2 box vLLM 0.23.0 → 0.24.0+ (the fix is inert without it).
- Smoke-test GLM-5.2 + Claude Code tool calls after the bump.

## Tests
4 new cases (Anthropic path, with-cache + legacy, streaming + non-streaming). Full suite 21 passed; ruff + mypy clean.