### PR TITLE
feat: reasoned 403 for blocked API keys from distributed invalid map

### DIFF
--- a/src/api_keys.py
+++ b/src/api_keys.py
@@ -1,4 +1,7 @@
+from http import HTTPStatus
+
 from fastapi import APIRouter, HTTPException
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from src.config import config
@@ -8,17 +11,52 @@ from src.cryptography import verify_signed_payload
 class KeysManager:
     _instance = None
     keys: set[str] = set()
+    # key -> {"reason": str, "message": str} for real-but-unusable keys (limits/credits/disabled)
+    invalid_keys: dict[str, dict] = {}
 
     def __new__(cls, *args, **kwargs):
         if not cls._instance:
             cls._instance = super(KeysManager, cls).__new__(cls, *args, **kwargs)
         return cls._instance
 
-    def reset_keys(self, new_keys: set[str]):
+    def reset_keys(self, new_keys: set[str], invalid_keys: dict[str, dict] | None = None):
         self.keys = new_keys
+        self.invalid_keys = invalid_keys or {}
 
     def key_exists(self, key):
         return key in self.keys
+
+
+def apply_key_payload(decrypted_data: dict) -> int:
+    """Update the KeysManager from a decrypted distribution payload; returns valid-key count."""
+    keys = decrypted_data.get("keys", [])
+    invalid_keys = decrypted_data.get("invalid_keys") or {}
+    KeysManager().reset_keys(set(keys), dict(invalid_keys))
+    return len(keys)
+
+
+def check_api_key(token: str) -> JSONResponse | None:
+    """None if the key is usable; otherwise the error response to return.
+
+    Blocked keys get an OpenAI-shaped 403 (`error.message` is what openai-node
+    displays); unknown keys keep the legacy 401 body.
+    """
+    keys_manager = KeysManager()
+    if keys_manager.key_exists(token):
+        return None
+    invalid_info = keys_manager.invalid_keys.get(token)
+    if invalid_info is not None:
+        return JSONResponse(
+            status_code=HTTPStatus.FORBIDDEN,
+            content={
+                "error": {
+                    "message": invalid_info.get("message") or "This API key is currently not usable.",
+                    "type": "invalid_request_error",
+                    "code": invalid_info.get("reason") or "forbidden",
+                }
+            },
+        )
+    return JSONResponse(status_code=HTTPStatus.UNAUTHORIZED, content={"detail": "Invalid API key"})
 
 
 router = APIRouter(tags=["LibertAI"], prefix="/libertai")
@@ -35,17 +73,9 @@ async def receive_api_keys(payload: EncryptedApiKeysPayload):
     The backend will call this endpoint with encrypted/signed keys.
     """
     try:
-        # Verify and decrypt the payload using the public key
         decrypted_data = verify_signed_payload(payload.encrypted_payload, config.API_PUBLIC_KEY)
-
-        # Extract the keys from the decrypted data
-        keys = decrypted_data.get("keys", [])
-
-        # Update the KeysManager with the new keys
-        keys_manager = KeysManager()
-        keys_manager.reset_keys(set(keys))
-
-        return {"status": "success", "keys_received": len(keys)}
+        keys_received = apply_key_payload(decrypted_data)
+        return {"status": "success", "keys_received": keys_received}
 
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"Error processing encrypted keys: {str(e)}")

--- a/src/image_routes.py
+++ b/src/image_routes.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel
 
-from src.api_keys import KeysManager
+from src.api_keys import check_api_key
 from src.config import ImageEditModelConfig, ImageModelConfig, config
 from src.image_generation import ImageModelManager, edit_image, generate_image
 from src.interfaces.usage import ImageUsage, ImageUsageFullData, UserContext
@@ -17,7 +17,6 @@ from src.usage import report_usage_event_task
 
 router = APIRouter(tags=["Image Generation"])
 security = HTTPBearer()
-keys_manager = KeysManager()
 image_manager = ImageModelManager()
 
 # Register image model configs
@@ -65,12 +64,8 @@ def validate_cfg_scale(cfg_scale: float) -> None:
         raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail="cfg_scale must be non-negative")
 
 
-def validate_model_and_endpoint(model_name: str, endpoint: str, token: str) -> ImageModelConfig | ImageEditModelConfig:
-    """Validate API key, model existence, model type, and endpoint path"""
-    # Auth validation
-    if not keys_manager.key_exists(token):
-        raise HTTPException(status_code=HTTPStatus.UNAUTHORIZED, detail="Invalid API key")
-
+def validate_model_and_endpoint(model_name: str, endpoint: str) -> ImageModelConfig | ImageEditModelConfig:
+    """Validate model existence, model type, and endpoint path. Auth is checked by the caller."""
     # Model existence
     if model_name not in config.MODEL_CONFIGS:
         raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=f"Model '{model_name}' not found")
@@ -177,7 +172,9 @@ async def generate_image_openai(
     payment_requirements = raw_request.headers.get("x-payment-requirements") or None
 
     # Validate model and endpoint
-    validate_model_and_endpoint(request.model, "v1/images/generations", token)
+    if (key_error := check_api_key(token)) is not None:
+        return key_error
+    validate_model_and_endpoint(request.model, "v1/images/generations")
 
     # Validate parameters
     if request.n < 1 or request.n > MAX_IMAGES:
@@ -285,7 +282,9 @@ async def edit_image_openai(
 
     # Validate
     validate_prompt(prompt)
-    validate_model_and_endpoint(model_name, "v1/images/edits", token)
+    if (key_error := check_api_key(token)) is not None:
+        return key_error
+    validate_model_and_endpoint(model_name, "v1/images/edits")
 
     if n < 1 or n > MAX_IMAGES:
         raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=f"n must be between 1 and {MAX_IMAGES}")
@@ -382,7 +381,9 @@ async def generate_image_a1111(
     payment_requirements = raw_request.headers.get("x-payment-requirements") or None
 
     # Validate model and endpoint
-    validate_model_and_endpoint(request.model, "sdapi/v1/txt2img", token)
+    if (key_error := check_api_key(token)) is not None:
+        return key_error
+    validate_model_and_endpoint(request.model, "sdapi/v1/txt2img")
 
     # Validate input parameters
     validate_prompt(request.prompt)

--- a/src/proxy.py
+++ b/src/proxy.py
@@ -9,7 +9,7 @@ from fastapi.responses import StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel
 
-from src.api_keys import KeysManager
+from src.api_keys import check_api_key
 from src.config import (
     AudioModelConfig,
     EmbeddingModelConfig,
@@ -27,7 +27,6 @@ from src.usage import report_usage_event_task, extract_usage_info_from_raw, extr
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["Proxy service"])
-keys_manager = KeysManager()
 security = HTTPBearer()
 
 timeout = httpx.Timeout(timeout=600.0)  # 10 minutes
@@ -147,8 +146,8 @@ async def proxy_request(
     background_tasks: BackgroundTasks,
 ):
     token = credentials.credentials
-    if not keys_manager.key_exists(token):
-        raise HTTPException(status_code=HTTPStatus.UNAUTHORIZED, detail="Invalid API key")
+    if (key_error := check_api_key(token)) is not None:
+        return key_error
 
     # Get model from request
     model_name = proxy_request_data.model

--- a/src/tts_routes.py
+++ b/src/tts_routes.py
@@ -6,7 +6,7 @@ from fastapi.responses import Response
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel
 
-from src.api_keys import KeysManager
+from src.api_keys import check_api_key
 from src.config import AudioModelConfig, config
 from src.interfaces.usage import AudioUsage, AudioUsageFullData, UserContext
 from src.tts_generation import TTSModelManager, synthesize_wav
@@ -14,7 +14,6 @@ from src.usage import report_usage_event_task
 
 router = APIRouter(tags=["Audio"])
 security = HTTPBearer()
-keys_manager = KeysManager()
 tts_manager = TTSModelManager()
 
 # Register audio model configs at import
@@ -35,9 +34,7 @@ class SpeechRequest(BaseModel):
     speed: float = 1.0
 
 
-def _validate(body: SpeechRequest, token: str) -> AudioModelConfig:
-    if not keys_manager.key_exists(token):
-        raise HTTPException(status_code=HTTPStatus.UNAUTHORIZED, detail="Invalid API key")
+def _validate(body: SpeechRequest) -> AudioModelConfig:
     if body.model not in config.MODEL_CONFIGS:
         raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=f"Model '{body.model}' not found")
     model_config = config.MODEL_CONFIGS[body.model]
@@ -80,7 +77,9 @@ async def create_speech(
     credentials: HTTPAuthorizationCredentials = Depends(security),
 ) -> Response:
     token = credentials.credentials
-    model_config = _validate(body, token)
+    if (key_error := check_api_key(token)) is not None:
+        return key_error
+    model_config = _validate(body)
     voice = body.voice or model_config.default_voice
 
     def _blocking() -> bytes:

--- a/tests/test_api_key_check.py
+++ b/tests/test_api_key_check.py
@@ -1,0 +1,40 @@
+import json
+
+from src.api_keys import KeysManager, apply_key_payload, check_api_key
+
+
+def _reset(keys=(), invalid=None):
+    KeysManager().reset_keys(set(keys), dict(invalid or {}))
+
+
+def test_apply_payload_with_invalid_map():
+    count = apply_key_payload({"keys": ["a"], "invalid_keys": {"b": {"reason": "expired", "message": "m"}}})
+    assert count == 1
+    assert KeysManager().key_exists("a")
+    assert KeysManager().invalid_keys == {"b": {"reason": "expired", "message": "m"}}
+
+
+def test_apply_payload_without_invalid_map_clears_stale_entries():
+    _reset(invalid={"old": {"reason": "expired", "message": "m"}})
+    apply_key_payload({"keys": ["a"]})
+    assert KeysManager().invalid_keys == {}
+
+
+def test_check_valid_key():
+    _reset(keys=["good"])
+    assert check_api_key("good") is None
+
+
+def test_check_blocked_key_403_openai_shape():
+    _reset(invalid={"blocked": {"reason": "no_credits", "message": "No credits."}})
+    resp = check_api_key("blocked")
+    assert resp.status_code == 403
+    body = json.loads(resp.body)
+    assert body == {"error": {"message": "No credits.", "type": "invalid_request_error", "code": "no_credits"}}
+
+
+def test_check_unknown_key_401_legacy_shape():
+    _reset()
+    resp = check_api_key("nope")
+    assert resp.status_code == 401
+    assert json.loads(resp.body) == {"detail": "Invalid API key"}

--- a/tests/test_proxy_image_inline.py
+++ b/tests/test_proxy_image_inline.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI, HTTPException
 from starlette.testclient import TestClient
 
 import src.proxy as proxy
+from src.api_keys import KeysManager
 from src.config import TextModelConfig
 
 
@@ -18,8 +19,8 @@ def client_and_capture(monkeypatch):
         allowed_paths=["v1/chat/completions", "v1/completions", "v1/messages", "v1/responses"],
     )
     monkeypatch.setitem(proxy.config.MODEL_CONFIGS, "visionmodel", model)
-    # Accept any bearer token; skip real usage reporting.
-    monkeypatch.setattr(proxy.keys_manager, "key_exists", lambda token: True)
+    # Accept the "k" bearer token used by every test in this file; skip real usage reporting.
+    KeysManager().reset_keys({"k"})
     monkeypatch.setattr(proxy, "report_usage_event_task", lambda *a, **k: None)
 
     captured: dict = {}

--- a/tests/test_route_auth.py
+++ b/tests/test_route_auth.py
@@ -1,0 +1,126 @@
+"""Auth-gate coverage: every route must reject unknown/blocked keys before touching
+model config or backend (image/tts pipelines, proxy upstream)."""
+import pytest
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+import src.image_routes as image_routes
+import src.proxy as proxy
+import src.tts_routes as tts_routes
+from src.api_keys import KeysManager
+
+BLOCKED_KEY = "blocked"
+BLOCKED_MAP = {BLOCKED_KEY: {"reason": "no_credits", "message": "No credits."}}
+FORBIDDEN_BODY = {"error": {"message": "No credits.", "type": "invalid_request_error", "code": "no_credits"}}
+UNAUTHORIZED_BODY = {"detail": "Invalid API key"}
+
+
+@pytest.fixture(autouse=True)
+def _restore_keys_manager():
+    km = KeysManager()
+    saved_keys, saved_invalid = km.keys, km.invalid_keys
+    yield
+    km.reset_keys(saved_keys, saved_invalid)
+
+
+def _client(router) -> TestClient:
+    KeysManager().reset_keys(set(), dict(BLOCKED_MAP))
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+@pytest.fixture
+def image_client():
+    return _client(image_routes.router)
+
+
+@pytest.fixture
+def tts_client():
+    return _client(tts_routes.router)
+
+
+@pytest.fixture
+def proxy_client():
+    return _client(proxy.router)
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# /v1/images/generations
+
+
+def test_images_generations_unknown_key(image_client):
+    r = image_client.post(
+        "/v1/images/generations", json={"model": "nope", "prompt": "hi"}, headers=_auth("unknown")
+    )
+    assert r.status_code == 401
+    assert r.json() == UNAUTHORIZED_BODY
+
+
+def test_images_generations_blocked_key(image_client):
+    r = image_client.post(
+        "/v1/images/generations", json={"model": "nope", "prompt": "hi"}, headers=_auth(BLOCKED_KEY)
+    )
+    assert r.status_code == 403
+    assert r.json() == FORBIDDEN_BODY
+
+
+# /v1/images/edits (multipart/form-data)
+
+
+def test_images_edits_unknown_key(image_client):
+    r = image_client.post(
+        "/v1/images/edits",
+        files={"prompt": (None, "hi"), "model": (None, "nope")},
+        headers=_auth("unknown"),
+    )
+    assert r.status_code == 401
+    assert r.json() == UNAUTHORIZED_BODY
+
+
+def test_images_edits_blocked_key(image_client):
+    r = image_client.post(
+        "/v1/images/edits",
+        files={"prompt": (None, "hi"), "model": (None, "nope")},
+        headers=_auth(BLOCKED_KEY),
+    )
+    assert r.status_code == 403
+    assert r.json() == FORBIDDEN_BODY
+
+
+# /sdapi/v1/txt2img
+
+
+def test_txt2img_unknown_key(image_client):
+    r = image_client.post("/sdapi/v1/txt2img", json={"model": "nope", "prompt": "hi"}, headers=_auth("unknown"))
+    assert r.status_code == 401
+    assert r.json() == UNAUTHORIZED_BODY
+
+
+def test_txt2img_blocked_key(image_client):
+    r = image_client.post(
+        "/sdapi/v1/txt2img", json={"model": "nope", "prompt": "hi"}, headers=_auth(BLOCKED_KEY)
+    )
+    assert r.status_code == 403
+    assert r.json() == FORBIDDEN_BODY
+
+
+# /v1/audio/speech (unknown-key case already covered by test_tts_routes.py)
+
+
+def test_speech_blocked_key(tts_client):
+    r = tts_client.post("/v1/audio/speech", json={"model": "nope", "input": "hi"}, headers=_auth(BLOCKED_KEY))
+    assert r.status_code == 403
+    assert r.json() == FORBIDDEN_BODY
+
+
+# text proxy route (catch-all POST /{full_path:path})
+
+
+def test_proxy_blocked_key(proxy_client):
+    r = proxy_client.post("/v1/chat/completions", json={"model": "nope"}, headers=_auth(BLOCKED_KEY))
+    assert r.status_code == 403
+    assert r.json() == FORBIDDEN_BODY

--- a/tests/test_tts_routes.py
+++ b/tests/test_tts_routes.py
@@ -2,6 +2,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from src.api_keys import KeysManager
 from src.config import AudioModelConfig
 import src.tts_routes as tts_routes
 
@@ -15,7 +16,7 @@ def client(monkeypatch):
         default_voice="af_heart",
     )
     monkeypatch.setattr(tts_routes.config, "MODEL_CONFIGS", {"kokoro": cfg})
-    monkeypatch.setattr(tts_routes.keys_manager, "key_exists", lambda token: token == "good")
+    KeysManager().reset_keys({"good"})
     app = FastAPI()
     app.include_router(tts_routes.router)
     return TestClient(app)


### PR DESCRIPTION
Part 3/3 of invalid-key reasons (with libertai-inference#60 and libertai-api#13).

Boxes now store the `invalid_keys` map from the distribution payload and answer blocked keys with the same OpenAI-shaped 403 as the gateway:

- `apply_key_payload`: reads `invalid_keys` when present, clears stale state when absent (old api payloads keep working).
- Shared `check_api_key`: valid → pass; blocked → 403 `{"error": {message, type, code}}`; unknown → legacy 401 `{"detail": "Invalid API key"}`. Wired into text proxy, image (all 3 endpoints), and tts routes.
- Deploy opportunistically per box; non-updated boxes keep working on `keys` only (api already serves the 403 in front).

Tests: 101 passed, incl. route-level auth coverage for every gated endpoint.